### PR TITLE
Fixed desktop selection - default desktop

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -155,10 +155,13 @@ textdomain="control"
                 <label_id>dummy_desktop</label_id>
                 <logon>gdm</logon>
                 <cursor>DMZ</cursor>
-                <!-- desktop_finish needs this to find out that gnome has been selected by user -->
-                <packages>gnome-shell</packages>
+                <!--
+                  desktop_finish needs this to find out that gnome has been selected by user
+                  bnc#866724: packages mentioned here are not selected by desktop selection
+                -->
+                <packages>patterns-sles-gnome</packages>
                 <order config:type="integer">1</order>
-                <patterns>base x11 gnome apparmor print_server 32bit 64bit x86 documentation</patterns>
+                <patterns>base x11 gnome apparmor print_server 32bit 64bit documentation</patterns>
                 <icon>pattern-gnome</icon>
             </one_supported_desktop>
             <one_supported_desktop>
@@ -167,10 +170,10 @@ textdomain="control"
                 <label_id>dummy_desktop</label_id>
                 <logon>gdm</logon>
                 <cursor>DMZ</cursor>
-                <!-- desktop_finish needs this to find out that icewm has been selected by user -->
+                <!-- desktop_finish needs this to find out that icewm has been selected by user manually -->
                 <packages>icewm</packages>
                 <order config:type="integer">2</order>
-                <patterns>base x11 apparmor print_server 32bit 64bit x86 documentation</patterns>
+                <patterns>base x11 apparmor print_server 32bit 64bit documentation</patterns>
                 <icon>yast-x11</icon>
             </one_supported_desktop>
         </supported_desktops>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar  6 14:30:13 CET 2014 - locilka@suse.com
+
+- Removed x86 pattern from default desktop selection (bnc#866724)
+- Fixed packages to identify a selected desktop - using package
+  that defines the gnome pattern (bnc#866724)
+- 12.0.14
+
+-------------------------------------------------------------------
 Thu Feb 27 07:03:47 UTC 2014 - mfilka@suse.com
 
 - added reference to linuxrc network configuration client


### PR DESCRIPTION
- Selected desktop is identified by the packages listed for a given desktop
- Using package that defines a gnome pattern as an identifier for GNOME
- Removed also x86 patern
- All according to bnc#866724
