### PR TITLE
Invoke inst_update_installer client after system_analysis

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -729,14 +729,14 @@ Please visit us at http://www.suse.com/.
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
+                    <label>System Analysis</label>
+                    <name>system_analysis</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
-                    <label>System Analysis</label>
-                    <name>system_analysis</name>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
@@ -960,14 +960,14 @@ Please visit us at http://www.suse.com/.
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
+                    <label>System Analysis</label>
+                    <name>system_analysis</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
-                    <label>System Analysis</label>
-                    <name>system_analysis</name>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
@@ -1102,14 +1102,14 @@ Please visit us at http://www.suse.com/.
             <stage>initial</stage>
             <modules config:type="list">
                 <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
+                    <label>System Analysis</label>
+                    <name>system_analysis</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
-                    <label>System Analysis</label>
-                    <name>system_analysis</name>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>

--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -1048,6 +1048,12 @@ Please visit us at http://www.suse.com/.
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
                 <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <label>AutoYaST Settings</label>
                     <name>autosetup</name>
                 </module>

--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -734,6 +734,7 @@ Please visit us at http://www.suse.com/.
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+		<!-- As soon as possible but after packager is initialized -->
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
@@ -965,6 +966,7 @@ Please visit us at http://www.suse.com/.
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+		<!-- As soon as possible but after packager is initialized -->
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
@@ -1047,6 +1049,7 @@ Please visit us at http://www.suse.com/.
                     <archs>all</archs>
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
+		<!-- As soon as possible but after packager is initialized -->
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
@@ -1107,6 +1110,7 @@ Please visit us at http://www.suse.com/.
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+		<!-- As soon as possible but after packager is initialized -->
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>

--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -729,6 +729,12 @@ Please visit us at http://www.suse.com/.
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
                     <enable_back>yes</enable_back>
@@ -954,6 +960,12 @@ Please visit us at http://www.suse.com/.
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>
                     <enable_back>yes</enable_back>
@@ -1083,6 +1095,12 @@ Please visit us at http://www.suse.com/.
             <mode>autoupgrade</mode>
             <stage>initial</stage>
             <modules config:type="list">
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
                 <module>
                     <label>System Analysis</label>
                     <name>system_analysis</name>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr  5 07:39:21 UTC 2016 - igonzalezsosa@suse.com
+
+- Automatically update the installer in the initial stage of:
+  installation, update, autoinstallation and autoupgrade.
+  Not affected: live_installation. (FATE#319716).
+- 12.0.48
+
+-------------------------------------------------------------------
 Mon Mar  7 14:01:46 UTC 2016 - mvidner@suse.com
 
 - Added a System Role step in the installation (FATE#317481).

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -84,7 +84,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.47
+Version:        12.0.48
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://fate.suse.com/319716
https://trello.com/c/T49hdvDd/498-5-self-update-change-dud-support-to-rpmmd-repository-with-rpms
https://github.com/yast/yast-installation/pull/356

The self-update client should be invoked from control file.