### PR TITLE
Disable system_roles module for PPC

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -767,6 +767,7 @@ Please visit us at http://www.suse.com/.
                 </module>
                 <module>
                     <name>system_role</name>
+		    <archs>aarch64,x86_64,s390</archs>
                 </module>
                  <module>
                     <label>Disk</label>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 25 10:57:47 UTC 2016 - igonzalezsosa@suse.com
+
+- Disable system_roles module for PowerPC because KVM and XEN
+  are not supported.
+- 12.0.49
+
+-------------------------------------------------------------------
 Tue Apr  5 07:39:21 UTC 2016 - igonzalezsosa@suse.com
 
 - Automatically update the installer in the initial stage of:

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -2,7 +2,7 @@
 Mon Apr 25 10:57:47 UTC 2016 - igonzalezsosa@suse.com
 
 - Disable system_roles module for PowerPC because KVM and XEN
-  are not supported.
+  are not supported (bsc#976558).
 - 12.0.49
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -84,7 +84,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.48
+Version:        12.0.49
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
* The reason is that KVM and XEN are not supported in PPC.
* [bsc#976558](https://bugzilla.suse.com/show_bug.cgi?id=976558)