### PR TITLE
Fate#319624

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -351,6 +351,11 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <name>firewall_stage1</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>80</presentation_order>
+                </proposal_module>
             </proposal_modules>
         </proposal>
 
@@ -397,6 +402,11 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <proposal_module>
                     <name>firewall_stage1</name>
                     <presentation_order>50</presentation_order>
+                </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>80</presentation_order>
                 </proposal_module>
             </proposal_modules>
         </proposal>
@@ -455,6 +465,11 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <proposal_module>
                     <name>default_target</name>
                     <presentation_order>55</presentation_order>
+                </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>80</presentation_order>
                 </proposal_module>
             </proposal_modules>
 

--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -52,42 +52,6 @@ textdomain="control"
             </save_instsys_item>
         </save_instsys_content>
 
-        <!-- FATE #305019: configure the files to copy from a previous installation -->
-        <copy_to_system config:type="list">
-            <!-- FATE #300421: Import ssh keys from previous installations -->
-            <copy_to_system_item>
-                <id>import_ssh_keys</id>
-                <copy_to_dir>/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_key.pub</file_item>
-                </mandatory_files>
-                <!-- Files thay may be present -->
-                <optional_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_dsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_dsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key.pub</file_item>
-                </optional_files>
-            </copy_to_system_item>
-
-            <!-- FATE #120103: Import Users From Existing Partition -->
-            <copy_to_system_item>
-                <id>import_users</id>
-                <copy_to_dir>/var/lib/YaST2/imported/userdata/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/shadow</file_item>
-                    <file_item>/etc/passwd</file_item>
-                    <file_item>/etc/login.defs</file_item>
-                    <file_item>/etc/group</file_item>
-                </mandatory_files>
-            </copy_to_system_item>
-        </copy_to_system>
-
         <!-- FATE: #304865: Enhance YaST Modules to cooperate better handling the product licenses -->
         <base_product_license_directory>/etc/YaST2/licenses/base/</base_product_license_directory>
 

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 16 19:53:00 UTC 2016 - ancor@suse.com
+
+- Removed not longer necessary items from copy_to_system section
+- Added SSH keys import section to the installation proposal
+- Fate#319624 
+- 12.0.51
+
+-------------------------------------------------------------------
 Tue May 10 12:05:00 UTC 2016 - jsrain@suse.cz
 
 - only offer system roles on x86 (bsc#976558)

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -84,7 +84,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.50
+Version:        12.0.51
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Added SSH keys import section to the proposal. See https://github.com/yast/yast-installation/pull/374
- Remove not longer necessary items from the `copy_to_system` section
  - SSH host keys no longer necessary. See https://build.opensuse.org/request/show/396066
  - Users database not longer necessary for user import. See https://build.opensuse.org/request/show/393918