### PR TITLE
Include the Ruby debugger (byebug) in the inst-sys (FATE#318421)

### DIFF
--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 25 10:17:50 UTC 2016 - igonzalezsosa@suse.com
+
+- Include the Ruby debugger (byebug) in the inst-sys for easier
+  YaST debugging (FATE#318421)
+- 12.0.52
+
+-------------------------------------------------------------------
 Mon May 16 19:53:00 UTC 2016 - ancor@suse.com
 
 - Removed not longer necessary items from copy_to_system section

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -68,6 +68,8 @@ Requires:       yast2-tune
 Requires:       yast2-update
 Requires:       yast2-users
 Requires:       yast2-x11
+# Ruby debugger in the inst-sys (FATE#318421)
+Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 
 # Architecture specific packages
 #
@@ -84,7 +86,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.51
+Version:        12.0.52
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Port of https://github.com/yast/skelcd-control-openSUSE/pull/45.