### PR TITLE
Install and enable xrdp by default (FATE#320363)

### DIFF
--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 23 12:41:37 UTC 2016 - varkoly@suse.com
+
+- Install and enable xrdp by default (FATE#320363)
+- 12.0.56
+
+-------------------------------------------------------------------
 Tue Jun 14 15:29:33 UTC 2016 - igonzalezsosa@suse.com
 
 - Delay self-update during autoupgrade until software manager

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -70,6 +70,9 @@ Requires:       yast2-users
 Requires:       yast2-x11
 # Ruby debugger in the inst-sys (FATE#318421)
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
+# Install and enable xrdp by default (FATE#320363)
+Requires:       yast2-rdp
+
 
 # Architecture specific packages
 #
@@ -86,7 +89,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.55
+Version:        12.0.56
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Install and enable xrdp by default ([FATE#320363](https://fate.suse.com/320363))
yast2-rdp will be only enabled in the proposal of SLES_SAP which has its own control.xml