### PR TITLE
Do not install desktop patterns for KVM and XEN system roles

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -212,6 +212,10 @@ textdomain="control"
         </partitioning>
         <software>
           <default_patterns>base Minimal kvm_server</default_patterns>
+          <!-- the cdata trick produces an empty string in the data
+               instead of omitting the key entirely -->
+          <optional_default_patterns><![CDATA[]]></optional_default_patterns>
+          <default_desktop><![CDATA[]]></default_desktop>
         </software>
       </system_role>
 
@@ -223,6 +227,8 @@ textdomain="control"
         </partitioning>
         <software>
           <default_patterns>base Minimal xen_server</default_patterns>
+          <optional_default_patterns><![CDATA[]]></optional_default_patterns>
+          <default_desktop><![CDATA[]]></default_desktop>
         </software>
       </system_role>
     </system_roles>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 12 11:48:13 UTC 2016 - mvidner@suse.com
+
+- Do not install desktop patterns for KVM and XEN system roles
+  (bsc#986640).
+- 12.0.56
+
+-------------------------------------------------------------------
 Tue Jun 14 15:29:33 UTC 2016 - igonzalezsosa@suse.com
 
 - Delay self-update during autoupgrade until software manager

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -86,7 +86,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.55
+Version:        12.0.56
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Reference: https://bugzilla.suse.com/show_bug.cgi?id=986640

Before this fix: even for a [KVM server role](https://github.com/yast/yast-installation/wiki/System-Role), desktop related patterns are included; the systemd target is graphical:

![too-many-patterns-01before](https://cloud.githubusercontent.com/assets/102056/16730378/e4a1056e-4772-11e6-9f4e-edb1dc10b65b.png)

With this fix, only the 3 patterns explicitly intended for the KVM role are selected, and no desktop related patterns. Accordingly, the system boots to text mode:

![too-many-patterns-02after](https://cloud.githubusercontent.com/assets/102056/16730188/c56fb448-4771-11e6-96f7-0aa8f12f5546.png)

Implementation: Override `optional_default_patterns` and `default_desktop` with empty values.
Note the use of a fancy XML empty string (with CDATA) so that Yast::XML includes the empty string in the resulting hash. A plain `<default_desktop/>` would omit the `"default_desktop"` key entirely.