### PR TITLE
Install and enable xrdp by default (FATE#320363)

### DIFF
--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
-Thu Jun 23 12:41:37 UTC 2016 - varkoly@suse.com
+Thu Jun 30 13:40:58 UTC 2016 - varkoly@suse.com
 
 - Install and enable xrdp by default (FATE#320363)
+  yast2-rdp is needed in installation system for the proposal.
 - 12.0.56
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 23 12:41:37 UTC 2016 - varkoly@suse.com
+
+- Install and enable xrdp by default (FATE#320363)
+- 12.0.56
+
+-------------------------------------------------------------------
 Tue Jun 14 15:29:33 UTC 2016 - igonzalezsosa@suse.com
 
 - Delay self-update during autoupgrade until software manager

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package skelcd-control-SLES
 #
-# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -32,7 +32,6 @@ Name:           skelcd-control-SLES
 BuildRequires:  libxml2-tools
 # RNG validation schema
 BuildRequires:  yast2-installation-control >= 3.1.9
-
 
 ######################################################################
 #
@@ -72,7 +71,6 @@ Requires:       yast2-x11
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 # Install and enable xrdp by default (FATE#320363)
 Requires:       yast2-rdp
-
 
 # Architecture specific packages
 #

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -70,6 +70,9 @@ Requires:       yast2-users
 Requires:       yast2-x11
 # Ruby debugger in the inst-sys (FATE#318421)
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
+# Install and enable xrdp by default (FATE#320363)
+Requires:       yast2-rdp
+
 
 # Architecture specific packages
 #
@@ -86,7 +89,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.55
+Version:        12.0.56
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Install and enable xrdp by default ([FATE#320363](https://fate.suse.com/320363))
yast2-rdp will be only enabled in the proposal of SLES_SAP which has its own control.xml

This supersedes #66 which was submitted to SLES before merging. @varkoly please do not do this!
See also the fat warning in the spec file:
```
######################################################################
#
# IMPORTANT: Please do not change the control file or this spec file
#   in build service directly, use
#   https://github.com/yast/skelcd-control-SLES repository
#
#   See https://github.com/yast/skelcd-control-SLES/blob/master/CONTRIBUTING.md
#   for more details.
#
######################################################################
```