### PR TITLE
Run the Inst-sys clean up (bsc#974601)

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -812,6 +812,14 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <module>
                     <label>Perform Installation</label>
                     <name>kickoff</name>
@@ -1028,6 +1036,14 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <label>Perform Update</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <module>
                     <label>Perform Update</label>
                     <name>kickoff</name>
@@ -1086,6 +1102,14 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <module>
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
+                </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
                 </module>
                 <module>
                     <label>Perform Installation</label>
@@ -1169,6 +1193,14 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <module>
                     <label>Perform Update</label>
                     <name>prepdisk</name>
+                </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
                 </module>
                 <module>
                     <label>Perform Update</label>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 21 11:30:11 UTC 2016 - lslezak@suse.cz
+
+- Remove some files from the inst-sys to have more free RAM on low
+  memory systems (bsc#974601)
+- 12.2.0
+
+-------------------------------------------------------------------
 Tue Jul 12 11:48:13 UTC 2016 - mvidner@suse.com
 
 - Do not install desktop patterns for KVM and XEN system roles

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -52,7 +52,8 @@ Requires:       yast2-devtools
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
 Requires:       yast2-firewall
-Requires:       yast2-installation >= 3.1.44
+# instsys_cleanup
+Requires:       yast2-installation >= 3.1.201
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
 Requires:       yast2-multipath
@@ -87,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.0.57
+Version:        12.2.0
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Remove some files from the inst-sys to have more free RAM on low memory systems.

This PR activates the cleaner (https://github.com/yast/yast-installation/pull/407) in the installation/upgrade workflow.

- Version updated to 12.2.0 (to match SP2, it seems we forgot to bump the minor version in SP1...)

The cleaner is called at the initial stage when the inst-sys is running in memory:

- Initial installation
- Upgrade
- Autoinstallation
- Autoupgrade