### PR TITLE
Added subvolumes to control.xml (fate#321737) 

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -186,6 +186,94 @@ textdomain="control"
         <btrfs_increase_percentage config:type="integer">300</btrfs_increase_percentage>
         <!-- the default subvolume "@" was requested by product management -->
         <btrfs_default_subvolume>@</btrfs_default_subvolume>
+
+        <!-- Subvolumes to be created for a Btrfs root file system -->
+        <!-- copy_on_write is true by default -->
+        <!-- The XML parser is very simplistic, thus not using attributes, but sub-elements -->
+        <subvolumes config:type="list">
+            <subvolume>
+                <path>home</path>
+            </subvolume>
+            <subvolume>
+                <path>opt</path>
+            </subvolume>
+            <subvolume>
+                <path>srv</path>
+            </subvolume>
+            <subvolume>
+                <path>tmp</path>
+            </subvolume>
+            <subvolume>
+                <path>usr/local</path>
+            </subvolume>
+            <subvolume>
+                <path>var/cache</path>
+            </subvolume>
+            <subvolume>
+                <path>var/crash</path>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/libvirt/images</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/machines</path>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/mailman</path>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/mariadb</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/mysql</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/named</path>
+            </subvolume>
+            <subvolume>
+                <path>var/lib/pgsql</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
+            </subvolume>
+            <subvolume>
+                <path>var/log</path>
+            </subvolume>
+            <subvolume>
+                <path>var/opt</path>
+            </subvolume>
+            <subvolume>
+                <path>var/spool</path>
+            </subvolume>
+            <subvolume>
+                <path>var/tmp</path>
+            </subvolume>
+
+            <!-- architecture specific subvolumes -->
+
+            <subvolume>
+                <path>boot/grub2/i386-pc</path>
+                <archs>i386,x86_64</archs>
+            </subvolume>
+            <subvolume>
+                <path>boot/grub2/x86_64-efi</path>
+                <archs>x86_64</archs>
+            </subvolume>
+            <subvolume>
+                <path>boot/grub2/powerpc-ieee1275</path>
+                <archs>ppc,!board_powernv</archs>
+            </subvolume>
+            <subvolume>
+                <path>boot/grub2/x86_64-efi</path>
+                <archs>x86_64</archs>
+            </subvolume>
+            <subvolume>
+                <path>boot/grub2/s390x-emu</path>
+                <archs>s390</archs>
+            </subvolume>
+        </subvolumes>
+
     </partitioning>
 
     <network>
@@ -292,9 +380,9 @@ for the selected scenario.</label>
         </roles_text>
         <roles_help>
           <!-- TRANSLATORS: dialog help -->
-          <label>&lt;p&gt;The system roles adjustments are in the range from package selection up 
-to disk partitioning. By choosing a system role, the system is 
-configured accordingly to match the use case of the role. The settings 
+          <label>&lt;p&gt;The system roles adjustments are in the range from package selection up
+to disk partitioning. By choosing a system role, the system is
+configured accordingly to match the use case of the role. The settings
 defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</label>
         </roles_help>
         <normal_role>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 27 15:25:45 CEST 2016 - shundhammer@suse.de
+
+- Added subvolumes (fate#321737)
+- 12.2.2.1
+
+-------------------------------------------------------------------
 Fri Aug 26 12:14:17 UTC 2016 - lslezak@suse.cz
 
 - Move the YaST self update step earlier in the workflow to avoid

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.2.2
+Version:        12.2.2.1
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://trello.com/c/JdvwBp5G/457-5-microos-12-sp2-move-default-subvolumes-to-control-file

Notice that right now Travis fails because it doesn't have the new schema yet. That is expected.

I tested this control.xml in my VM. It also validates against the updated schema.

For comparison, the fallback list (taken from the old code), which is the same as the subvolumes in this PR, is here:
https://github.com/yast/yast-storage/blob/SLE-12-SP2-CASP/src/lib/storage/subvol.rb#L36
https://github.com/yast/yast-storage/blob/SLE-12-SP2-CASP/src/lib/storage/subvol.rb#L165
