### PR TITLE
Revert "Improve the Travis check"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ services:
 before_install:
   - docker build -t yast-skelcd-control-sles-image .
 script:
-  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
-  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-sles-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-sles-image ./.travis.sh

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,3 @@ Yast::Tasks.configuration do |conf|
   conf.skip_license_check << /.*/
 end
 
-# check also the syntax of the XML files
-task :"check:syntax" do
-  sh "make -C control check"
-end


### PR DESCRIPTION
This reverts commit 6190a0160839deb998acefa458a1284b5eb48600 (PR #77).

The rake check:syntax is also called at Jenkins, it does not work
there and breaks the package submission.