### PR TITLE
Use proper SLES 15 self_update_url (bsc#1051637)

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -80,8 +80,8 @@ textdomain="control"
             </service>
         </services_proposal>
 
-	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12-SP3/$arch/update</self_update_url>
+        <!-- self-update URL -->
+        <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/15/$arch/update</self_update_url>
     </globals>
 
     <software>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 11 13:18:10 UTC 2017 - knut.anderssen@suse.com
+
+- Fixed SLES 15 self_update_url (bsc#1051637)
+- 15.0.2
+
+-------------------------------------------------------------------
 Thu Aug  3 06:31:13 UTC 2017 - jreidinger@suse.com
 
 - place skelcd to /usr/lib/skelcd (bsc#1031335)

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -91,7 +91,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.0.1
+Version:        15.0.2
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
It will prepare it for the future. The repository does not exist yet, but the use of SLES-12-SP3 will raise a bug once some package get published in the installer update repository.