### PR TITLE
removed minimal_base pattern from minimal role (bsc#1064135)

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -149,7 +149,7 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
 
                 <order config:type="integer">1000</order>
                 <software>
-                  <default_patterns>base minimal_base</default_patterns>
+                  <default_patterns>base</default_patterns>
                   <!-- the cdata trick produces an empty string in the data
                        instead of omitting the key entirely -->
                   <optional_default_patterns><![CDATA[]]></optional_default_patterns>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 19 10:47:17 UTC 2017 - jsrain@suse.cz
+
+- removed minimal_base pattern from minimal role (bsc#1064135)
+
+-------------------------------------------------------------------
 Thu Oct 19 06:04:23 UTC 2017 - jsrain@suse.cz
 
 - re-added base pattern to minimal role (bsc#1064135)


### PR DESCRIPTION
no need to submit now, with next change is sufficient, that's why no version bump