### PR TITLE
/var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -73,6 +73,10 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <path>var/crash</path>
             </subvolume>
             <subvolume>
+                <path>var/lib/ceph</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
+            </subvolume>
+            <subvolume>
                 <path>var/lib/libvirt/images</path>
                 <copy_on_write config:type="boolean">false</copy_on_write>
             </subvolume>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  6 00:22:46 UTC 2017 - kmroz@suse.com
+
+- /var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)
+- 15.0.12
+
+-------------------------------------------------------------------
 Thu Oct 19 10:47:17 UTC 2017 - jsrain@suse.cz
 
 - removed minimal_base pattern from minimal role (bsc#1064135)

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -92,7 +92,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.0.11
+Version:        15.0.12
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
Signed-off-by: Karol Mroz <kmroz@suse.de>