### PR TITLE
Display the product license at upgrade (bsc#1069124)

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -339,6 +339,12 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
+                    <label>Product License</label>
+                    <name>product_upgrade_license</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <name>upgrade_urls</name>
                     <enable_back>yes</enable_back>
                 </module>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 17 13:28:22 UTC 2018 - lslezak@suse.cz
+
+- Display the product license at upgrade (just after selecting
+  the root partition) (bsc#1069124)
+- 15.0.15
+
+-------------------------------------------------------------------
 Mon Jan 15 14:08:48 UTC 2018 - snwint@suse.com
 
 - rewrite partitioning section to use new storage-ng settings

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -63,6 +63,8 @@ Requires:       yast2-ntp-client
 Requires:       yast2-proxy
 Requires:       yast2-services-manager
 Requires:       yast2-configuration-management
+# clients/inst_product_upgrade_license.rb
+Requires:       yast2-packager >= 4.0.29
 Requires:       yast2-slp
 Requires:       yast2-trans-stats
 Requires:       yast2-tune
@@ -92,7 +94,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.0.14
+Version:        15.0.15
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Display the license dialog just after selecting the root partition
- See https://bugzilla.suse.com/show_bug.cgi?id=1069124
- 15.0.15
- :100: :tada: 