### PR TITLE
Add 'fcoe-client' to the list of clonable modules

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -341,6 +341,7 @@ textdomain="control"
         <clone_module>ca_mgm</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 10:06:50 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991)
+- 12.3.5
+
+-------------------------------------------------------------------
 Wed Apr 26 10:15:32 CEST 2017 - schubi@suse.de
 
 - Added yast2-configuration-management to inst-sys.

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -89,7 +89,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.3.4
+Version:        12.3.5
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe