### PR TITLE
Add 'fcoe-client' to the list of clonable modules (SP2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /package/skelcd-control-SLES-*.tar.bz2
+doc/
+.yardoc/
+control.pot

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e -x
+
+make -C control check
+
+# the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+# see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+yast-travis-ruby
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p yast2-installation-control
-script:
-    - cd control
-    - make check
+sudo: required
+language: bash
+services:
+    - docker
 
+before_install:
+    - docker build -t yast-skelcd-control-sles-image .
+script:
+    - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-sles-image ./.travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby:sle12-sp2
+COPY . /usr/src/app
+

--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -253,6 +253,7 @@ textdomain="control"
         <clone_module>ca_mgm</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 14 17:30:47 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991)
+- 12.2.3
+
+-------------------------------------------------------------------
 Fri Aug 26 12:14:17 UTC 2016 - lslezak@suse.cz
 
 - Move the YaST self update step earlier in the workflow to avoid

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.2.2
+Version:        12.2.3
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe)