### PR TITLE
Add regexps to match "SUSE Linux Enterprise High Performance Computing"

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -90,6 +90,7 @@ textdomain="control"
         <!-- For SLES12, unmaintained (old) packages are not removed by default, FATE #301844, bugzilla #233156 -->
         <delete_old_packages_reverse_list config:type="list">
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 12.*$</regexp_item>
+            <regexp_item>^SUSE (LINUX|Linux) Enterprise H.*P.*C.* 12.*$</regexp_item>
         </delete_old_packages_reverse_list>
 
         <!-- By default, packages can be downgraded -->
@@ -97,6 +98,7 @@ textdomain="control"
         <!-- For SLES12, packages are not downgraded, FATE #301990, bugzilla #238488 -->
         <silently_downgrade_packages_reverse_list config:type="list">
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 12.*$</regexp_item>
+            <regexp_item>^SUSE (LINUX|Linux) Enterprise H.*P.*C.* 12.*$</regexp_item>
         </silently_downgrade_packages_reverse_list>
 
         <!-- By default, select new packages for installation -->
@@ -104,12 +106,14 @@ textdomain="control"
         <!-- For SLES 12, do not install new packages by default, FATE #301844, bugzilla #871174 -->
         <only_update_selected_reverse_list config:type="list">
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 12.*$</regexp_item>
+            <regexp_item>^SUSE (LINUX|Linux) Enterprise H.*P.*C.* 12.*$</regexp_item>
         </only_update_selected_reverse_list>
 
         <!-- Only upgrading from SLES11 or SLES12 is supported, otherwise warning is displayed -->
         <products_supported_for_upgrade config:type="list">
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 11.*$</regexp_item>
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 12.*$</regexp_item>
+            <regexp_item>^SUSE (LINUX|Linux) Enterprise H.*P.*C.* 12.*$</regexp_item>
         </products_supported_for_upgrade>
 
         <selection_type config:type="symbol">auto</selection_type>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue May 22 09:38:24 UTC 2018 - eich@suse.com
+
+- Add regexps to match "SUSE Linux Enterprise High Performance Computing"
+  These regexp will cause update settings for migration being changed for
+  matching products.
+  The additions will keep SLE-HPC in sync with SLES (bsc#1094166).
+- 12.4.0
+
+-------------------------------------------------------------------
 Thu Mar  8 10:06:50 UTC 2018 - knut.anderssen@suse.com
 
 - Added the fcoe-client to the list of clonable modules

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -89,7 +89,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.3.5
+Version:        12.4.0
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
These regexp will cause update settings for migration being changed for
matching products.
The additions will keep SLE-HPC in sync with SLES (bsc#1094166).
Version 12.4.0

Signed-off-by: Egbert Eich <eich@suse.com>