### PR TITLE
WIP: Update skelcd-control-SLES to use  with BCL bundle (do NOT merge it before beta2)

### DIFF
--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -80,6 +80,8 @@ Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 Requires:       yast2-rdp
 
 Provides:       system-installation() = SLES
+# Additional provides to use SLES version with BCL bundle
+Provides:       system-installation() = SLES_BCL
 
 # Architecture specific packages
 #


### PR DESCRIPTION
Update skelcd-control-SLES to use with BCL bundle as well  as suggested by Jiri.
Other option would be forking it to be more flexible in future and starting with a "clone" just exchanging SLES with SLES_BCL