### PR TITLE
Set NoCOW for /var/log Btrfs subvolume

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -243,6 +243,7 @@ textdomain="control"
             </subvolume>
             <subvolume>
                 <path>var/log</path>
+                <copy_on_write config:type="boolean">false</copy_on_write>
             </subvolume>
             <subvolume>
                 <path>var/opt</path>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  6 12:40:08 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Optimize /var for Btrfs setting /var/log as NoCOW (jsc#sle-6864)
+- 12.5.0
+
+-------------------------------------------------------------------
 Tue May 22 09:38:24 UTC 2018 - eich@suse.com
 
 - Add regexps to match "SUSE Linux Enterprise High Performance Computing"

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -89,7 +89,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.4.0
+Version:        12.5.0
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
As part of the `Optimize /var for Btrfs use` epic, the _/var/log_ subvolume will be configured as **NoCOW**.

- https://trello.com/c/l8VQI362 

---

Tested manually via driver update.

<details>
<summary>Click to show/hide screenshots</summary>

---

![/var/log NoCOW in the proposal](https://user-images.githubusercontent.com/1691872/59034987-3f342580-8864-11e9-8b55-4af3039e5e87.png)

![/var/log NoCOW in the installed system](https://user-images.githubusercontent.com/1691872/59035028-51ae5f00-8864-11e9-8d38-578e9b598460.png)
</details>

