### PR TITLE
Add comment about s390

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -150,6 +150,10 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <min_size config:type="disksize">1 GiB</min_size>
                 <max_size config:type="disksize">2 GiB</max_size>
                 <weight config:type="integer">10</weight>
+		<!-- The option to resume from RAM is not available for Z Systems.
+		     For this reason, in s390 the default value of adjust_by_ram
+		     is forced to false for the swap volume, even when it was set
+		     to true here. -->
                 <adjust_by_ram config:type="boolean">true</adjust_by_ram>
                 <adjust_by_ram_configurable config:type="boolean">true</adjust_by_ram_configurable>
 

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 16 11:10:10 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Add comment about s390 and default value of adjust_by_ram,
+  see jsc#SLE-6926.
+
+-------------------------------------------------------------------
 Wed Jan 16 17:04:22 CET 2019 - schubi@suse.de
 
 - Supporting special product SLES_BCL (fate#327099).


### PR DESCRIPTION
During the review meeting it was agreed to add a comment directly to the control file to explain the default value of `adjust_by_ram` setting in s390 for swap.

Related to https://trello.com/c/xNInsz6m/1088-1-storage-enlarge-to-ram-set-to-false-by-default-for-s390