### PR TITLE
Skip the registration step (jsc#SLE-7214)

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -202,6 +202,13 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <name>scc</name>
                 <enable_back>yes</enable_back>
                 <enable_next>yes</enable_next>
+                <!-- Skip the registration on the new online medium (already registered
+                     at this point) and offline medium (registration not required). -->
+                <!-- TODO: Remove this step completely once the old Installer and
+                     Packages DVD are dropped. -->
+                <arguments>
+                    <skip>online,offline</skip>
+                </arguments>
             </module>
             <module>
                 <label>System Analysis</label>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 24 08:26:19 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Skip the registration step on the online and offline installation
+  medium (jsc#SLE-7214)
+- 15.2.0
+
+-------------------------------------------------------------------
 Tue Jul 16 11:10:10 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Add comment about s390 and default value of adjust_by_ram,

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -100,7 +100,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.1.1
+Version:        15.2.0
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Skip the registration on the new online medium (the system has been already registered                     at this point) and offline medium (registration is not required there).
- The registration step is only kept for the backward compatibility for the old Installer medium to not break the current openQA tests.
- It can be removed completely once the old Installer and Packages DVD are dropped.
- Related to https://github.com/yast/yast-registration/pull/444
- 15.2.0