### PR TITLE
Fixed the default self_update URL for SP5 (bsc#1152275)

### DIFF
--- a/control/control.SLES.xml
+++ b/control/control.SLES.xml
@@ -81,7 +81,7 @@ textdomain="control"
         </services_proposal>
 
 	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12-SP3/$arch/update</self_update_url>
+	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12-SP5/$arch/update</self_update_url>
     </globals>
 
     <software>

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 27 10:12:18 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed the default self_update URL for SP5 (bsc#1152275)
+- 12.5.1
+
+-------------------------------------------------------------------
 Thu Jun  6 12:40:08 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Optimize /var for Btrfs setting /var/log as NoCOW (jsc#sle-6864)

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -94,7 +94,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        12.5.0
+Version:        12.5.1
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1152275
- 12.5.1
- (We should really avoid hardcoding the version... :worried: )