### PR TITLE
Preselect the Basesystem and Server Applications modules (bsc#1171814)

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -9,7 +9,9 @@ textdomain="control"
     <textdomain>control</textdomain>
 
     <software>
-        <!-- the default preselected modules for the Full installation medium -->
+        <!-- the default preselected modules for the Full installation medium
+             https://bugzilla.suse.com/show_bug.cgi?id=1171814
+             https://jira.suse.com/browse/SLE-8040 -->
         <default_modules config:type="list">
             <default_module>sle-module-basesystem</default_module>
             <default_module>sle-module-server-applications</default_module>

--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -8,6 +8,14 @@ textdomain="control"
 
     <textdomain>control</textdomain>
 
+    <software>
+        <!-- the default preselected modules for the Full installation medium -->
+        <default_modules config:type="list">
+            <default_module>sle-module-basesystem</default_module>
+            <default_module>sle-module-server-applications</default_module>
+        </default_modules>
+    </software>
+
     <texts>
         <roles_caption>
           <!-- TRANSLATORS: dialog caption -->

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 27 07:42:22 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Preselect the Basesystem and Server Applications modules
+  when using the Full installation medium (bsc#1171814)
+- 15.2.2
+
+-------------------------------------------------------------------
 Wed Dec  4 18:29:36 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the registration also on the Full medium (jsc#SLE-7214)

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -100,7 +100,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.2.1
+Version:        15.2.2
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
- See [bsc#1171814](https://bugzilla.suse.com/show_bug.cgi?id=1171814)
- Added new defaults for the Full installation medium
- The original feature request [SLE-8040](https://jira.suse.com/browse/SLE-8040) requested only the Basesystem module... :angry:  
- 15.2.2