### PR TITLE
Security settings

### DIFF
--- a/control/installation.SLES.xml
+++ b/control/installation.SLES.xml
@@ -8,6 +8,14 @@ textdomain="control"
 
     <textdomain>control</textdomain>
 
+    <globals>
+        <!-- Set SELinux permissive mode by default -->
+        <selinux>
+          <mode>enforcing</mode>
+          <configurable config:type="boolean">true</configurable>
+          <patterns>selinux</patterns>
+        </selinux>
+    </globals>
     <software>
         <!-- the default preselected modules for the Full installation medium
              https://bugzilla.suse.com/show_bug.cgi?id=1171814

--- a/package/skelcd-control-SLES.changes
+++ b/package/skelcd-control-SLES.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 25 09:50:24 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set SELinux permissive mode by default (related to jsc#SLE-17307)
+- 15.3.6
+
+-------------------------------------------------------------------
 Tue Jan 19 14:19:08 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix for SLE kde migration to use only runtime requirements

--- a/package/skelcd-control-SLES.spec
+++ b/package/skelcd-control-SLES.spec
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLES
 AutoReqProv:    off
-Version:        15.3.5
+Version:        15.3.6
 Release:        0
 Summary:        SLES control file needed for installation
 License:        MIT


### PR DESCRIPTION
###  :warning: `do not merge it yet`, **pending of SELinux pattern confirmation**  :warning:

Related to https://jira.suse.com/browse/SLE-17307 (internal link), sets SELinux as a major [**L**inux **S**ecurity **M**odule](https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html) using the `enforcing` mode.

--- 

See https://github.com/yast/yast-security/pull/87 for more details.